### PR TITLE
Add token support

### DIFF
--- a/client.c
+++ b/client.c
@@ -37,11 +37,18 @@ void consul_client_setup_user(consul_client_t* client, const char *user, const c
     client->settings.user = strdup(user);
 }
 
+void consul_client_setup_token(consul_client_t* client, const char *token) {
+    client->settings.token = strdup(token);
+}
+
 void consul_client_destroy(consul_client_t* client) {
     int i = 0;
 
     if (client->settings.user) {
         free(client->settings.user);
+    }
+    if (client->settings.token) {
+        free(client->settings.token);
     }
 
     for (i = 0; i < client->server_count; i++) {

--- a/consul.h
+++ b/consul.h
@@ -78,6 +78,7 @@ typedef struct consul_client_t {
         char*    user;
         char*    password;
         char*    scheme;
+        char*    token;
     } settings;
 } consul_client_t;
 
@@ -151,6 +152,7 @@ void consul_server_cleanup(consul_server_t* server);
 
 consul_client_t* consul_client_create(int server_count, const char** servers);
 void consul_client_setup_user(consul_client_t* client, const char *user, const char *password);
+void consul_client_setup_token(consul_client_t* client, const char *token);
 void consul_client_destroy(consul_client_t* client);
 consul_response_t *consul_client_lsdir(consul_client_t *cli, const char *key, int recursive);
 consul_response_t* consul_cluster_request(consul_client_t* client, consul_request_t* req);


### PR DESCRIPTION
Added Consul Token support by call `consul_client_setup_token()`.
The feature was lost while migration from res_discovery_consul to res_consul_discovery.
It's using `X-Consul-Token` header instead deprecated `?token=` query parameter.