### PR TITLE
Add TLSServerName and TLSSkipVerify to the check

### DIFF
--- a/consul.h
+++ b/consul.h
@@ -113,6 +113,8 @@ typedef struct consul_response_t {
 typedef struct consul_check_t {
     const char *http;
     int interval;
+    const char *tls_server_name;
+    int tls_skip_verify;
 } consul_check_t;
 
 typedef struct consul_service_t {

--- a/service.c
+++ b/service.c
@@ -32,7 +32,8 @@ static json_t* strings_to_json_dict(const char** strings) {
 static json_t* check_to_json_dict(consul_check_t *check) {
     char interval[32];
     snprintf(interval, 32, "%ds", check->interval);
-    return json_pack("{s:s?,s:s}", "HTTP", check->http, "Interval", interval);
+    return json_pack("{s:s?,s:s,s:s?,s:b}", "HTTP", check->http, "Interval", interval,
+                     "TLSServerName",check->tls_server_name, "TLSSkipVerify", check->tls_skip_verify);
 }
 
 static json_t* checks_to_json_array(consul_check_t **checks) {


### PR DESCRIPTION
Added `TLSServerName` and `TLSSkipVerify` params to Consul Check.

[Check - Agent HTTP API](https://www.consul.io/api-docs/v1.12.x/agent/check)